### PR TITLE
Remote Theme Enabled

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ search: true
 
 # Build settings
 markdown: kramdown
-theme: minimal-mistakes-jekyll
+remote_theme: mmistakes/minimal-mistakes@4.20.1
 # Outputting
 permalink: /:categories/:title/
 paginate: 5 # amount of posts to show


### PR DESCRIPTION
Changing from GitHub Pages to Remote theme because GitHub Pages does not support local gem themes.